### PR TITLE
Set cue color via gui

### DIFF
--- a/res/skins/Deere/deck_visual_row.xml
+++ b/res/skins/Deere/deck_visual_row.xml
@@ -26,8 +26,6 @@
         <SignalRGBHighColor></SignalRGBHighColor>
         <SignalRGBMidColor></SignalRGBMidColor>
         <SignalRGBLowColor></SignalRGBLowColor>
-        <Black>#00FFFF</Black>
-        <Yellow>#FF0000</Yellow>
         <SignalColor><Variable name="DeckSignalColor"/></SignalColor>
         <BeatColor>#ffffff</BeatColor>
         <PlayPosColor>#00FF00</PlayPosColor>

--- a/res/skins/Deere/deck_visual_row.xml
+++ b/res/skins/Deere/deck_visual_row.xml
@@ -26,6 +26,8 @@
         <SignalRGBHighColor></SignalRGBHighColor>
         <SignalRGBMidColor></SignalRGBMidColor>
         <SignalRGBLowColor></SignalRGBLowColor>
+        <Black>#00FFFF</Black>
+        <Yellow>#FF0000</Yellow>
         <SignalColor><Variable name="DeckSignalColor"/></SignalColor>
         <BeatColor>#ffffff</BeatColor>
         <PlayPosColor>#00FF00</PlayPosColor>

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -17,58 +17,6 @@
 const int kFilterLength = 80;
 const int kMinBpm = 30;
 
-// NOTE(Swiftb0y): Maybe this should be defined somewhere more global/logical?
-
-const static QList<QString> ColorNames = {
-     QObject::tr("Red"),
-     QObject::tr("Green"),
-     QObject::tr("Yellow"),
-     QObject::tr("Blue"),
-     QObject::tr("Orange"),
-     QObject::tr("Purple"),
-     QObject::tr("Cyan"),
-     QObject::tr("Magenta"),
-     QObject::tr("Lime"),
-     QObject::tr("Pink"),
-     QObject::tr("Teal"),
-     QObject::tr("Lavender"),
-     QObject::tr("Brown"),
-     QObject::tr("Beige"),
-     QObject::tr("Maroon"),
-     QObject::tr("Mint"),
-     QObject::tr("Olive"),
-     QObject::tr("Apricot"),
-     QObject::tr("Navy"),
-     QObject::tr("Grey"),
-     QObject::tr("White"),
-     QObject::tr("Black"),
-};
-
-const static QList<QColor> Colors = {
-     QColor("#E6194B"),
-     QColor("#3CB44B"),
-     QColor("#FFE119"),
-     QColor("#4363D8"),
-     QColor("#F58231"),
-     QColor("#911EB4"),
-     QColor("#42D4F4"),
-     QColor("#F032E6"),
-     QColor("#BFEF45"),
-     QColor("#FABEBE"),
-     QColor("#469990"),
-     QColor("#E6BEFF"),
-     QColor("#9A6324"),
-     QColor("#FFFAC8"),
-     QColor("#800000"),
-     QColor("#AAFFC3"),
-     QColor("#808000"),
-     QColor("#FFD8B1"),
-     QColor("#000075"),
-     QColor("#A9A9A9"),
-     QColor("#FFFFFF"),
-     QColor("#000000"),
-};
-
 // Maximum allowed interval between beats (calculated from kMinBpm).
 const mixxx::Duration kMaxInterval = mixxx::Duration::fromMillis(1000.0 * (60.0 / kMinBpm));
 
@@ -89,8 +37,6 @@ void DlgTrackInfo::init() {
 
     cueTable->hideColumn(0);
     coverBox->insertWidget(1, m_pWCoverArtLabel);
-
-    RELEASE_ASSERT(ColorNames.length() == Colors.length());
 
     connect(btnNext, SIGNAL(clicked()),
             this, SLOT(slotNext()));
@@ -391,17 +337,19 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
 
 
         QComboBox* colorComboBox = new QComboBox();
-        for (int i = 0 ; i < ColorNames.length() ;i++) {
-            const QColor color = Colors.at(i);
-            colorComboBox->addItem(ColorNames.at(i),color);
+        QList<QColor> predefinedColors = Color::predefinedColors();
+        for (int i = 0; i < predefinedColors.count(); i++) {
+            QColor color = predefinedColors.at(i);
+            colorComboBox->addItem(Color::displayName(color), color);
             const QModelIndex idx = colorComboBox->model()->index(i, 0);
             colorComboBox->model()->setData(idx, color, Qt::BackgroundColorRole);
-            // TODO (Swiftb0y): put color choosing function into util/color.h
-            colorComboBox->setItemData(i, chooseContrastColor(color), Qt::TextColorRole);
+            colorComboBox->setItemData(i, Color::chooseContrastColor(color), Qt::TextColorRole);
 
         }
         const QColor cueColor = pCue->getColor();
-        colorComboBox->setCurrentIndex(Colors.contains(cueColor) ? Colors.indexOf(cueColor) : 0);
+        colorComboBox->setCurrentIndex(predefinedColors.contains(cueColor)
+                ? predefinedColors.indexOf(cueColor)
+                : 0);
 
         m_cueMap[row] = pCue;
         cueTable->insertRow(row);
@@ -482,7 +430,8 @@ void DlgTrackInfo::saveTrack() {
 
         auto colorComboBox = qobject_cast<QComboBox*>(colorWidget);
         if (colorComboBox) {
-            const auto color = Colors.at(colorComboBox->currentIndex());
+            QList<QColor> predefinedColors = Color::predefinedColors();
+            QColor color = predefinedColors.at(colorComboBox->currentIndex());
             if (color.isValid()) {
                 pCue->setColor(color);
             }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -337,7 +337,7 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
 
 
         QComboBox* colorComboBox = new QComboBox();
-        QList<QColor> predefinedColors = Color::predefinedColors();
+        const QList<QColor>& predefinedColors = Color::predefinedColors;
         for (int i = 0; i < predefinedColors.count(); i++) {
             QColor color = predefinedColors.at(i);
             colorComboBox->addItem(Color::displayName(color), color);
@@ -430,8 +430,7 @@ void DlgTrackInfo::saveTrack() {
 
         auto colorComboBox = qobject_cast<QComboBox*>(colorWidget);
         if (colorComboBox) {
-            QList<QColor> predefinedColors = Color::predefinedColors();
-            QColor color = predefinedColors.at(colorComboBox->currentIndex());
+            QColor color = Color::predefinedColors.at(colorComboBox->currentIndex());
             if (color.isValid()) {
                 pCue->setColor(color);
             }

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -14,6 +14,7 @@
 
 #include "preferences/usersettings.h"
 #include "skin/pixmapsource.h"
+#include "util/color.h"
 #include "widget/wsingletoncontainer.h"
 #include "widget/wpixmapstore.h"
 
@@ -264,6 +265,18 @@ class SkinContext {
 
     double getScaleFactor() const {
         return m_scaleFactor;
+    }
+
+    ColorsRepresentation getCueColorsRepresentation(const QDomNode& node) const {
+        ColorsRepresentation colorsReprsentation = Color::defaultRepresentation;
+        for (QLatin1String colorName : Color::predefinedColorsNames) {
+            QColor representation = selectColor(node, "Cue" + colorName);
+            if (representation.isValid()) {
+                QColor originalColor = Color::predefinedColorFromName(colorName);
+                colorsReprsentation.setRepresentation(originalColor, representation);
+            }
+        }
+        return colorsReprsentation;
     }
 
   private:

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -213,7 +213,7 @@ namespace Color {
 
     // Returns a new default colors representation, i.e. maps each default color to itself.
     // Stores the color's name() property, e.g. "#A9A9A9"
-    static std::unique_ptr<ColorsRepresentation> defaultRepresentation() {
+    static std::unique_ptr<ColorsRepresentation> makeDefaultRepresentation() {
         std::unique_ptr<ColorsRepresentation> representation = std::make_unique<ColorsRepresentation>();
         for (QColor color : predefinedColors()) {
             representation->setRepresentation(color, color);

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -29,6 +29,7 @@ class ColorsRepresentation final {
     QHash<QString, QString> colorNameMap;
 };
 
+// These methods and properties are not thread-safe, use them only on the GUI thread
 namespace Color {
     static const QColor Red      = QColor("#E6194B");
     static const QColor Green    = QColor("#3CB44B");
@@ -54,63 +55,58 @@ namespace Color {
     static const QColor Black    = QColor("#000000");
 
     // Return a list with the predefined colors.
-    static QList<QColor> predefinedColors() {
-        return QList<QColor> {
-            Red,
-            Green,
-            Yellow,
-            Blue,
-            Orange,
-            Purple,
-            Cyan,
-            Magenta,
-            Lime,
-            Pink,
-            Teal,
-            Lavender,
-            Brown,
-            Beige,
-            Maroon,
-            Mint,
-            Olive,
-            Apricot,
-            Navy,
-            Grey,
-            White,
-            Black,
-        };
+    static const QList<QColor> predefinedColors {
+        Red,
+        Green,
+        Yellow,
+        Blue,
+        Orange,
+        Purple,
+        Cyan,
+        Magenta,
+        Lime,
+        Pink,
+        Teal,
+        Lavender,
+        Brown,
+        Beige,
+        Maroon,
+        Mint,
+        Olive,
+        Apricot,
+        Navy,
+        Grey,
+        White,
+        Black,
     };
 
     // Return a list with the internal names of the predefined colors.
-    static QList<QLatin1String> predefinedColorsNames() {
-        return QList<QLatin1String> {
-            QLatin1String("Red"),
-            QLatin1String("Green"),
-            QLatin1String("Yellow"),
-            QLatin1String("Blue"),
-            QLatin1String("Orange"),
-            QLatin1String("Purple"),
-            QLatin1String("Cyan"),
-            QLatin1String("Magenta"),
-            QLatin1String("Lime"),
-            QLatin1String("Pink"),
-            QLatin1String("Teal"),
-            QLatin1String("Lavender"),
-            QLatin1String("Brown"),
-            QLatin1String("Beige"),
-            QLatin1String("Maroon"),
-            QLatin1String("Mint"),
-            QLatin1String("Olive"),
-            QLatin1String("Apricot"),
-            QLatin1String("Navy"),
-            QLatin1String("Grey"),
-            QLatin1String("White"),
-            QLatin1String("Black"),
-        };
+    static const QList<QLatin1String> predefinedColorsNames {
+        QLatin1String("Red"),
+        QLatin1String("Green"),
+        QLatin1String("Yellow"),
+        QLatin1String("Blue"),
+        QLatin1String("Orange"),
+        QLatin1String("Purple"),
+        QLatin1String("Cyan"),
+        QLatin1String("Magenta"),
+        QLatin1String("Lime"),
+        QLatin1String("Pink"),
+        QLatin1String("Teal"),
+        QLatin1String("Lavender"),
+        QLatin1String("Brown"),
+        QLatin1String("Beige"),
+        QLatin1String("Maroon"),
+        QLatin1String("Mint"),
+        QLatin1String("Olive"),
+        QLatin1String("Apricot"),
+        QLatin1String("Navy"),
+        QLatin1String("Grey"),
+        QLatin1String("White"),
+        QLatin1String("Black"),
     };
 
     // Return a predefined color code from its internal name.
-    // TODO: use literals here
     static QColor predefinedColorFromName(QLatin1String name) {
         if (name == QLatin1String("Red")) {
             return Red;
@@ -215,7 +211,7 @@ namespace Color {
     // Stores the color's name() property, e.g. "#A9A9A9"
     static std::unique_ptr<ColorsRepresentation> makeDefaultRepresentation() {
         std::unique_ptr<ColorsRepresentation> representation = std::make_unique<ColorsRepresentation>();
-        for (QColor color : predefinedColors()) {
+        for (QColor color : predefinedColors) {
             representation->setRepresentation(color, color);
         }
         return representation;

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -30,130 +30,131 @@ class ColorsRepresentation final {
 };
 
 namespace Color {
-    static const QString Red      = "#E6194B";
-    static const QString Green    = "#3CB44B";
-    static const QString Yellow   = "#FFE119";
-    static const QString Blue     = "#4363D8";
-    static const QString Orange   = "#F58231";
-    static const QString Purple   = "#911EB4";
-    static const QString Cyan     = "#42D4F4";
-    static const QString Magenta  = "#F032E6";
-    static const QString Lime     = "#BFEF45";
-    static const QString Pink     = "#FABEBE";
-    static const QString Teal     = "#469990";
-    static const QString Lavender = "#E6BEFF";
-    static const QString Brown    = "#9A6324";
-    static const QString Beige    = "#FFFAC8";
-    static const QString Maroon   = "#800000";
-    static const QString Mint     = "#AAFFC3";
-    static const QString Olive    = "#808000";
-    static const QString Apricot  = "#FFD8B1";
-    static const QString Navy     = "#000075";
-    static const QString Grey     = "#A9A9A9";
-    static const QString White    = "#FFFFFF";
-    static const QString Black    = "#000000";
+    static const QColor Red      = QColor("#E6194B");
+    static const QColor Green    = QColor("#3CB44B");
+    static const QColor Yellow   = QColor("#FFE119");
+    static const QColor Blue     = QColor("#4363D8");
+    static const QColor Orange   = QColor("#F58231");
+    static const QColor Purple   = QColor("#911EB4");
+    static const QColor Cyan     = QColor("#42D4F4");
+    static const QColor Magenta  = QColor("#F032E6");
+    static const QColor Lime     = QColor("#BFEF45");
+    static const QColor Pink     = QColor("#FABEBE");
+    static const QColor Teal     = QColor("#469990");
+    static const QColor Lavender = QColor("#E6BEFF");
+    static const QColor Brown    = QColor("#9A6324");
+    static const QColor Beige    = QColor("#FFFAC8");
+    static const QColor Maroon   = QColor("#800000");
+    static const QColor Mint     = QColor("#AAFFC3");
+    static const QColor Olive    = QColor("#808000");
+    static const QColor Apricot  = QColor("#FFD8B1");
+    static const QColor Navy     = QColor("#000075");
+    static const QColor Grey     = QColor("#A9A9A9");
+    static const QColor White    = QColor("#FFFFFF");
+    static const QColor Black    = QColor("#000000");
 
     // Return a list with the predefined colors.
     static QList<QColor> predefinedColors() {
         return QList<QColor> {
-            QColor(Red),
-            QColor(Green),
-            QColor(Yellow),
-            QColor(Blue),
-            QColor(Orange),
-            QColor(Purple),
-            QColor(Cyan),
-            QColor(Magenta),
-            QColor(Lime),
-            QColor(Pink),
-            QColor(Teal),
-            QColor(Lavender),
-            QColor(Brown),
-            QColor(Beige),
-            QColor(Maroon),
-            QColor(Mint),
-            QColor(Olive),
-            QColor(Apricot),
-            QColor(Navy),
-            QColor(Grey),
-            QColor(White),
-            QColor(Black),
+            Red,
+            Green,
+            Yellow,
+            Blue,
+            Orange,
+            Purple,
+            Cyan,
+            Magenta,
+            Lime,
+            Pink,
+            Teal,
+            Lavender,
+            Brown,
+            Beige,
+            Maroon,
+            Mint,
+            Olive,
+            Apricot,
+            Navy,
+            Grey,
+            White,
+            Black,
         };
     };
 
     // Return a list with the internal names of the predefined colors.
-    static QList<QString> predefinedColorsNames() {
-        return QList<QString> {
-            "Red",
-            "Green",
-            "Yellow",
-            "Blue",
-            "Orange",
-            "Purple",
-            "Cyan",
-            "Magenta",
-            "Lime",
-            "Pink",
-            "Teal",
-            "Lavender",
-            "Brown",
-            "Beige",
-            "Maroon",
-            "Mint",
-            "Olive",
-            "Apricot",
-            "Navy",
-            "Grey",
-            "White",
-            "Black",
+    static QList<QLatin1String> predefinedColorsNames() {
+        return QList<QLatin1String> {
+            QLatin1String("Red"),
+            QLatin1String("Green"),
+            QLatin1String("Yellow"),
+            QLatin1String("Blue"),
+            QLatin1String("Orange"),
+            QLatin1String("Purple"),
+            QLatin1String("Cyan"),
+            QLatin1String("Magenta"),
+            QLatin1String("Lime"),
+            QLatin1String("Pink"),
+            QLatin1String("Teal"),
+            QLatin1String("Lavender"),
+            QLatin1String("Brown"),
+            QLatin1String("Beige"),
+            QLatin1String("Maroon"),
+            QLatin1String("Mint"),
+            QLatin1String("Olive"),
+            QLatin1String("Apricot"),
+            QLatin1String("Navy"),
+            QLatin1String("Grey"),
+            QLatin1String("White"),
+            QLatin1String("Black"),
         };
     };
 
     // Return a predefined color code from its internal name.
-    static QString predefinedColorFromName(QString name) {
-        if (name == "Red") {
+    // TODO: use literals here
+    static QColor predefinedColorFromName(QLatin1String name) {
+        if (name == QLatin1String("Red")) {
             return Red;
-        } else if (name == "Green") {
+        } else if (name == QLatin1String("Green")) {
             return Green;
-        } else if (name == "Yellow") {
+        } else if (name == QLatin1String("Yellow")) {
             return Yellow;
-        } else if (name == "Blue") {
+        } else if (name == QLatin1String("Blue")) {
             return Blue;
-        } else if (name == "Orange") {
+        } else if (name == QLatin1String("Orange")) {
             return Orange;
-        } else if (name == "Purple") {
+        } else if (name == QLatin1String("Purple")) {
             return Purple;
-        } else if (name == "Cyan") {
+        } else if (name == QLatin1String("Cyan")) {
             return Cyan;
-        } else if (name == "Magenta") {
+        } else if (name == QLatin1String("Magenta")) {
             return Magenta;
-        } else if (name == "Lime") {
+        } else if (name == QLatin1String("Lime")) {
             return Lime;
-        } else if (name == "Pink") {
+        } else if (name == QLatin1String("Pink")) {
             return Pink;
-        } else if (name == "Teal") {
+        } else if (name == QLatin1String("Teal")) {
             return Teal;
-        } else if (name == "Lavender") {
+        } else if (name == QLatin1String("Lavender")) {
             return Lavender;
-        } else if (name == "Brown") {
+        } else if (name == QLatin1String("Brown")) {
             return Brown;
-        } else if (name == "Beige") {
+        } else if (name == QLatin1String("Beige")) {
             return Beige;
-        } else if (name == "Maroon") {
+        } else if (name == QLatin1String("Maroon")) {
             return Maroon;
-        } else if (name == "Mint") {
+        } else if (name == QLatin1String("Mint")) {
             return Mint;
-        } else if (name == "Olive") {
+        } else if (name == QLatin1String("Olive")) {
             return Olive;
-        } else if (name == "Apricot") {
+        } else if (name == QLatin1String("Apricot")) {
             return Apricot;
-        } else if (name == "Navy") {
+        } else if (name == QLatin1String("Navy")) {
             return Navy;
-        } else if (name == "Grey") {
+        } else if (name == QLatin1String("Grey")) {
             return Grey;
-        } else if (name == "White") {
+        } else if (name == QLatin1String("White")) {
             return White;
-        } else if (name == "Black") {
+        } else if (name == QLatin1String("Black")) {
             return Black;
         }
         return Black;
@@ -162,49 +163,49 @@ namespace Color {
     // Return the localized name of a predefined color.
     // Returns "Undefined Color" if color is not a predefined color.
     static QString displayName(QColor color) {
-        if (color.name().toUpper() == Red.toUpper()) {
+        if (color == Red) {
             return QObject::tr("Red");
-        } else if (color.name().toUpper() == Green.toUpper()) {
+        } else if (color == Green) {
             return QObject::tr("Green");
-        } else if (color.name().toUpper() == Yellow.toUpper()) {
+        } else if (color == Yellow) {
             return QObject::tr("Yellow");
-        } else if (color.name().toUpper() == Blue.toUpper()) {
+        } else if (color == Blue) {
             return QObject::tr("Blue");
-        } else if (color.name().toUpper() == Orange.toUpper()) {
+        } else if (color == Orange) {
             return QObject::tr("Orange");
-        } else if (color.name().toUpper() == Purple.toUpper()) {
+        } else if (color == Purple) {
             return QObject::tr("Purple");
-        } else if (color.name().toUpper() == Cyan.toUpper()) {
+        } else if (color == Cyan) {
             return QObject::tr("Cyan");
-        } else if (color.name().toUpper() == Magenta.toUpper()) {
+        } else if (color == Magenta) {
             return QObject::tr("Magenta");
-        } else if (color.name().toUpper() == Lime.toUpper()) {
+        } else if (color == Lime) {
             return QObject::tr("Lime");
-        } else if (color.name().toUpper() == Pink.toUpper()) {
+        } else if (color == Pink) {
             return QObject::tr("Pink");
-        } else if (color.name().toUpper() == Teal.toUpper()) {
+        } else if (color == Teal) {
             return QObject::tr("Teal");
-        } else if (color.name().toUpper() == Lavender.toUpper()) {
+        } else if (color == Lavender) {
             return QObject::tr("Lavender");
-        } else if (color.name().toUpper() == Brown.toUpper()) {
+        } else if (color == Brown) {
             return QObject::tr("Brown");
-        } else if (color.name().toUpper() == Beige.toUpper()) {
+        } else if (color == Beige) {
             return QObject::tr("Beige");
-        } else if (color.name().toUpper() == Maroon.toUpper()) {
+        } else if (color == Maroon) {
             return QObject::tr("Maroon");
-        } else if (color.name().toUpper() == Mint.toUpper()) {
+        } else if (color == Mint) {
             return QObject::tr("Mint");
-        } else if (color.name().toUpper() == Olive.toUpper()) {
+        } else if (color == Olive) {
             return QObject::tr("Olive");
-        } else if (color.name().toUpper() == Apricot.toUpper()) {
+        } else if (color == Apricot) {
             return QObject::tr("Apricot");
-        } else if (color.name().toUpper() == Navy.toUpper()) {
+        } else if (color == Navy){
             return QObject::tr("Navy");
-        } else if (color.name().toUpper() == Grey.toUpper()) {
+        } else if (color == Grey) {
             return QObject::tr("Grey");
-        } else if (color.name().toUpper() == White.toUpper()) {
+        } else if (color == White) {
             return QObject::tr("White");
-        } else if (color.name().toUpper() == Black.toUpper()) {
+        } else if (color == Black) {
             return QObject::tr("Black");
         }
         return QObject::tr("Undefined Color");

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -2,51 +2,264 @@
 #define COLOR_H
 
 #include "util/math.h"
+#include "util/memory.h"
 
 #include <QColor>
+#include <QMap>
 
 #define BRIGHTNESS_TRESHOLD 130
 
-// algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
-// NOTE(Swiftb0y): please suggest if I should you use other methods
-// (like the W3C algorithm) or if this approach is to to performance hungry
-// NOTE: the author did not take alpha transparency into account!
-inline int brightness(int red, int green, int blue) {
-    return static_cast<int>(sqrtf(
-        red * red * .241 +
-        green * green * .691 +
-        blue * blue * .068)
-    );
+// Map the predefined colors to another color representation of them.
+class ColorsRepresentation final {
+  public:
+    // Set a color representation for a given color
+    void setRepresentation(QColor color, QColor representation) {
+        colorNameMap[color.name()] = representation.name();
+    }
+
+    // Returns the representation of a color
+    QColor map(QColor color) const {
+        if (colorNameMap.contains(color.name())) {
+            return QColor(colorNameMap[color.name()]);
+        }
+        return color;
+    }
+
+  private:
+    QHash<QString, QString> colorNameMap;
 };
 
-inline int brightness(QColor color) {
-    return brightness(color.red(), color.green(), color.red());
-}
+namespace Color {
+    static const QString Red      = "#E6194B";
+    static const QString Green    = "#3CB44B";
+    static const QString Yellow   = "#FFE119";
+    static const QString Blue     = "#4363D8";
+    static const QString Orange   = "#F58231";
+    static const QString Purple   = "#911EB4";
+    static const QString Cyan     = "#42D4F4";
+    static const QString Magenta  = "#F032E6";
+    static const QString Lime     = "#BFEF45";
+    static const QString Pink     = "#FABEBE";
+    static const QString Teal     = "#469990";
+    static const QString Lavender = "#E6BEFF";
+    static const QString Brown    = "#9A6324";
+    static const QString Beige    = "#FFFAC8";
+    static const QString Maroon   = "#800000";
+    static const QString Mint     = "#AAFFC3";
+    static const QString Olive    = "#808000";
+    static const QString Apricot  = "#FFD8B1";
+    static const QString Navy     = "#000075";
+    static const QString Grey     = "#A9A9A9";
+    static const QString White    = "#FFFFFF";
+    static const QString Black    = "#000000";
 
-inline bool isDimmColor(QColor color) {
-    qDebug() << color.name();
-    return brightness(color) < BRIGHTNESS_TRESHOLD;
-}
+    // Return a list with the predefined colors.
+    static QList<QColor> predefinedColors() {
+        return QList<QColor> {
+            QColor(Red),
+            QColor(Green),
+            QColor(Yellow),
+            QColor(Blue),
+            QColor(Orange),
+            QColor(Purple),
+            QColor(Cyan),
+            QColor(Magenta),
+            QColor(Lime),
+            QColor(Pink),
+            QColor(Teal),
+            QColor(Lavender),
+            QColor(Brown),
+            QColor(Beige),
+            QColor(Maroon),
+            QColor(Mint),
+            QColor(Olive),
+            QColor(Apricot),
+            QColor(Navy),
+            QColor(Grey),
+            QColor(White),
+            QColor(Black),
+        };
+    };
 
-// if the ColorToChooseBy is darker than the global threshold,
-// the Color from the second argument will be returned.
+    // Return a list with the internal names of the predefined colors.
+    static QList<QString> predefinedColorsNames() {
+        return QList<QString> {
+            "Red",
+            "Green",
+            "Yellow",
+            "Blue",
+            "Orange",
+            "Purple",
+            "Cyan",
+            "Magenta",
+            "Lime",
+            "Pink",
+            "Teal",
+            "Lavender",
+            "Brown",
+            "Beige",
+            "Maroon",
+            "Mint",
+            "Olive",
+            "Apricot",
+            "Navy",
+            "Grey",
+            "White",
+            "Black",
+        };
+    };
 
-inline QColor chooseColorByBrightnessB(bool precalculated, QColor dimmColor , QColor brightColor) {
-    return precalculated ? dimmColor : brightColor;
-}
+    // Return a predefined color code from its internal name.
+    static QString predefinedColorFromName(QString name) {
+        if (name == "Red") {
+            return Red;
+        } else if (name == "Green") {
+            return Green;
+        } else if (name == "Yellow") {
+            return Yellow;
+        } else if (name == "Blue") {
+            return Blue;
+        } else if (name == "Orange") {
+            return Orange;
+        } else if (name == "Purple") {
+            return Purple;
+        } else if (name == "Cyan") {
+            return Cyan;
+        } else if (name == "Magenta") {
+            return Magenta;
+        } else if (name == "Lime") {
+            return Lime;
+        } else if (name == "Pink") {
+            return Pink;
+        } else if (name == "Teal") {
+            return Teal;
+        } else if (name == "Lavender") {
+            return Lavender;
+        } else if (name == "Brown") {
+            return Brown;
+        } else if (name == "Beige") {
+            return Beige;
+        } else if (name == "Maroon") {
+            return Maroon;
+        } else if (name == "Mint") {
+            return Mint;
+        } else if (name == "Olive") {
+            return Olive;
+        } else if (name == "Apricot") {
+            return Apricot;
+        } else if (name == "Navy") {
+            return Navy;
+        } else if (name == "Grey") {
+            return Grey;
+        } else if (name == "White") {
+            return White;
+        } else if (name == "Black") {
+            return Black;
+        }
+        return Black;
+    };
 
-inline QColor chooseColorByBrightness(QColor ColorToChooseBy, QColor dimmColor , QColor brightColor) {
-    return chooseColorByBrightnessB(isDimmColor(ColorToChooseBy), dimmColor,  brightColor);
-}
+    // Return the localized name of a predefined color.
+    // Returns "Undefined Color" if color is not a predefined color.
+    static QString displayName(QColor color) {
+        if (color.name().toUpper() == Red.toUpper()) {
+            return QObject::tr("Red");
+        } else if (color.name().toUpper() == Green.toUpper()) {
+            return QObject::tr("Green");
+        } else if (color.name().toUpper() == Yellow.toUpper()) {
+            return QObject::tr("Yellow");
+        } else if (color.name().toUpper() == Blue.toUpper()) {
+            return QObject::tr("Blue");
+        } else if (color.name().toUpper() == Orange.toUpper()) {
+            return QObject::tr("Orange");
+        } else if (color.name().toUpper() == Purple.toUpper()) {
+            return QObject::tr("Purple");
+        } else if (color.name().toUpper() == Cyan.toUpper()) {
+            return QObject::tr("Cyan");
+        } else if (color.name().toUpper() == Magenta.toUpper()) {
+            return QObject::tr("Magenta");
+        } else if (color.name().toUpper() == Lime.toUpper()) {
+            return QObject::tr("Lime");
+        } else if (color.name().toUpper() == Pink.toUpper()) {
+            return QObject::tr("Pink");
+        } else if (color.name().toUpper() == Teal.toUpper()) {
+            return QObject::tr("Teal");
+        } else if (color.name().toUpper() == Lavender.toUpper()) {
+            return QObject::tr("Lavender");
+        } else if (color.name().toUpper() == Brown.toUpper()) {
+            return QObject::tr("Brown");
+        } else if (color.name().toUpper() == Beige.toUpper()) {
+            return QObject::tr("Beige");
+        } else if (color.name().toUpper() == Maroon.toUpper()) {
+            return QObject::tr("Maroon");
+        } else if (color.name().toUpper() == Mint.toUpper()) {
+            return QObject::tr("Mint");
+        } else if (color.name().toUpper() == Olive.toUpper()) {
+            return QObject::tr("Olive");
+        } else if (color.name().toUpper() == Apricot.toUpper()) {
+            return QObject::tr("Apricot");
+        } else if (color.name().toUpper() == Navy.toUpper()) {
+            return QObject::tr("Navy");
+        } else if (color.name().toUpper() == Grey.toUpper()) {
+            return QObject::tr("Grey");
+        } else if (color.name().toUpper() == White.toUpper()) {
+            return QObject::tr("White");
+        } else if (color.name().toUpper() == Black.toUpper()) {
+            return QObject::tr("Black");
+        }
+        return QObject::tr("Undefined Color");
+    };
 
-inline QColor chooseContrastColor(QColor colorToChooseBy) {
-    return chooseColorByBrightness(colorToChooseBy, QColor(255,255,255,255), QColor(0,0,0,255));
-}
+    // Returns a new default colors representation, i.e. maps each default color to itself.
+    // Stores the color's name() property, e.g. "#A9A9A9"
+    static std::unique_ptr<ColorsRepresentation> defaultRepresentation() {
+        std::unique_ptr<ColorsRepresentation> representation = std::make_unique<ColorsRepresentation>();
+        for (QColor color : predefinedColors()) {
+            representation->setRepresentation(color, color);
+        }
+        return representation;
+    }
 
-inline QColor chooseContrastColorB(bool precalculated) {
-    return chooseColorByBrightnessB(precalculated, QColor(255,255,255,255), QColor(0,0,0,255));
-}
 
+    // algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+    // NOTE(Swiftb0y): please suggest if I should you use other methods
+    // (like the W3C algorithm) or if this approach is to to performance hungry
+    // NOTE: the author did not take alpha transparency into account!
+    static inline int brightness(int red, int green, int blue) {
+        return static_cast<int>(sqrtf(
+            red * red * .241 +
+            green * green * .691 +
+            blue * blue * .068)
+        );
+    };
 
+    static inline int brightness(QColor color) {
+        return brightness(color.red(), color.green(), color.red());
+    }
 
+    static inline bool isDimmColor(QColor color) {
+//        qDebug() << color.name();
+        return brightness(color) < BRIGHTNESS_TRESHOLD;
+    }
+
+    // if the ColorToChooseBy is darker than the global threshold,
+    // the Color from the second argument will be returned.
+
+    static inline QColor chooseColorByBrightnessB(bool precalculated, QColor dimmColor , QColor brightColor) {
+        return precalculated ? dimmColor : brightColor;
+    }
+
+    static inline QColor chooseColorByBrightness(QColor ColorToChooseBy, QColor dimmColor , QColor brightColor) {
+        return chooseColorByBrightnessB(isDimmColor(ColorToChooseBy), dimmColor,  brightColor);
+    }
+
+    static inline QColor chooseContrastColor(QColor colorToChooseBy) {
+        return chooseColorByBrightness(colorToChooseBy, QColor(255,255,255,255), QColor(0,0,0,255));
+    }
+
+    static inline QColor chooseContrastColorB(bool precalculated) {
+        return chooseColorByBrightnessB(precalculated, QColor(255,255,255,255), QColor(0,0,0,255));
+    }
+
+};
 #endif /* COLOR_H */

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -376,7 +376,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
-    for (QLatin1String colorName : Color::predefinedColorsNames()) {
+    for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -374,7 +374,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 }
 
 void WaveformRenderMark::setupColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_pPredefinedColorsRepresentation = Color::defaultRepresentation();
+    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {
         QColor representation = context.selectColor(node, colorName);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -23,7 +23,7 @@ WaveformRenderMark::WaveformRenderMark(
 }
 
 void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
-    setupCueColorsRepresentation(node, context);
+    m_predefinedColorsRepresentation = context.getCueColorsRepresentation(node);
     m_marks.setup(m_waveformRenderer->getGroup(), node, context,
                   *m_waveformRenderer->getWaveformSignalColors());
 }
@@ -370,17 +370,5 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         painter.setPen(QColor(0,0,0,100));
         painter.drawLine(middle - 1, lineTop, middle - 1, lineBottom);
         painter.drawLine(middle + 1, lineTop, middle + 1, lineBottom);
-    }
-}
-
-void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_predefinedColorsRepresentation = Color::defaultRepresentation;
-
-    for (QLatin1String colorName : Color::predefinedColorsNames) {
-        QColor representation = context.selectColor(node, "Cue" + colorName);
-        if (representation.isValid()) {
-            QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
-        }
     }
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -110,7 +110,7 @@ void WaveformRenderMark::slotCuesUpdated() {
         }
 
         QString newLabel = pCue->getLabel();
-        QColor newColor = m_pPredefinedColorsRepresentation->map(pCue->getColor());
+        QColor newColor = m_predefinedColorsRepresentation.map(pCue->getColor());
 
         // Here we assume no two cues can have the same hotcue assigned,
         // because WaveformMarkSet stores one mark for each hotcue.
@@ -374,13 +374,13 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 }
 
 void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
+    m_predefinedColorsRepresentation = Color::defaultRepresentation;
 
     for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
+            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
         }
     }
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -376,11 +376,11 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 void WaveformRenderMark::setupColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::defaultRepresentation();
 
-    for (QString colorName : Color::predefinedColorsNames()) {
+    for (QLatin1String colorName : Color::predefinedColorsNames()) {
         QColor representation = context.selectColor(node, colorName);
         if (representation.isValid()) {
-            QString colorCode = Color::predefinedColorFromName(colorName);
-            m_pPredefinedColorsRepresentation->setRepresentation(colorCode, representation);
+            QColor originalColor = Color::predefinedColorFromName(colorName);
+            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
         }
     }
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -23,7 +23,7 @@ WaveformRenderMark::WaveformRenderMark(
 }
 
 void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
-    setupColorsRepresentation(node, context);
+    setupCueColorsRepresentation(node, context);
     m_marks.setup(m_waveformRenderer->getGroup(), node, context,
                   *m_waveformRenderer->getWaveformSignalColors());
 }
@@ -373,7 +373,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
     }
 }
 
-void WaveformRenderMark::setupColorsRepresentation(const QDomNode& node, const SkinContext& context) {
+void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -377,7 +377,7 @@ void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, cons
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {
-        QColor representation = context.selectColor(node, colorName);
+        QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
             m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -33,7 +33,7 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
-    void setupColorsRepresentation(const QDomNode& node, const SkinContext& context);
+    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
 
     std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
 

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -35,7 +35,7 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
     void generateMarkImage(WaveformMark* pMark);
     void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
 
-    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
+    ColorsRepresentation m_predefinedColorsRepresentation;
 
     WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -33,7 +33,6 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
-    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
 
     ColorsRepresentation m_predefinedColorsRepresentation;
 

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -33,6 +33,9 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
+    void setupColorsRepresentation(const QDomNode& node, const SkinContext& context);
+
+    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
 
     WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -85,7 +85,7 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     }
 
     // setup hotcues and cue and loop(s)
-    setupCueColorsRepresentation(node, context);
+    m_predefinedColorsRepresentation = context.getCueColorsRepresentation(node);
     m_marks.setup(m_group, node, context, m_signalColors);
 
     for (const auto& pMark: m_marks) {
@@ -636,16 +636,4 @@ void WOverview::dropEvent(QDropEvent* event) {
         }
     }
     event->ignore();
-}
-
-void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_predefinedColorsRepresentation = Color::defaultRepresentation;
-
-    for (QLatin1String colorName : Color::predefinedColorsNames) {
-        QColor representation = context.selectColor(node, "Cue" + colorName);
-        if (representation.isValid()) {
-            QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
-        }
-    }
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -639,7 +639,7 @@ void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinCon
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {
-        QColor representation = context.selectColor(node, colorName);
+        QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
             m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -270,7 +270,7 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
         if (currentMark && currentMark->isValid()) {
             WaveformMarkProperties markProperties = currentMark->getProperties();
-            const QColor newColor = m_pPredefinedColorsRepresentation->map(currentCue->getColor());
+            const QColor newColor = m_predefinedColorsRepresentation.map(currentCue->getColor());
 
             if (newColor != markProperties.m_color || newColor != markProperties.m_textColor) {
                 markProperties.m_color = newColor;
@@ -639,13 +639,13 @@ void WOverview::dropEvent(QDropEvent* event) {
 }
 
 void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
+    m_predefinedColorsRepresentation = Color::defaultRepresentation;
 
     for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
+            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
         }
     }
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -641,7 +641,7 @@ void WOverview::dropEvent(QDropEvent* event) {
 void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
-    for (QLatin1String colorName : Color::predefinedColorsNames()) {
+    for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -26,6 +26,7 @@
 #include "wskincolor.h"
 #include "widget/controlwidgetconnection.h"
 #include "track/track.h"
+#include "util/color.h"
 #include "util/math.h"
 #include "util/timer.h"
 #include "util/dnd.h"
@@ -84,6 +85,7 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     }
 
     // setup hotcues and cue and loop(s)
+    setupCueColorsRepresentation(node, context);
     m_marks.setup(m_group, node, context, m_signalColors);
 
     for (const auto& pMark: m_marks) {
@@ -265,7 +267,7 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
         if (currentMark && currentMark->isValid()) {
             WaveformMarkProperties markProperties = currentMark->getProperties();
-            const QColor newColor = currentCue->getColor();
+            const QColor newColor = m_pPredefinedColorsRepresentation->map(currentCue->getColor());
 
             if (newColor != markProperties.m_color || newColor != markProperties.m_textColor) {
                 markProperties.m_color = newColor;
@@ -631,4 +633,16 @@ void WOverview::dropEvent(QDropEvent* event) {
         }
     }
     event->ignore();
+}
+
+void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
+    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
+
+    for (QLatin1String colorName : Color::predefinedColorsNames()) {
+        QColor representation = context.selectColor(node, colorName);
+        if (representation.isValid()) {
+            QColor originalColor = Color::predefinedColorFromName(colorName);
+            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
+        }
+    }
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -203,6 +203,9 @@ void WOverview::slotAnalyzerProgress(int progress) {
 void WOverview::slotTrackLoaded(TrackPointer pTrack) {
     DEBUG_ASSERT(m_pCurrentTrack == pTrack);
     m_trackLoaded = true;
+    if (m_pCurrentTrack) {
+        updateCues(m_pCurrentTrack->getCuePoints());
+    }
     update();
 }
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -95,6 +95,7 @@ class WOverview : public WWidget {
     // Append the waveform overview pixmap according to available data in waveform
     virtual bool drawNextPixmapPart() = 0;
     void paintText(const QString &text, QPainter *painter);
+    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
     inline int valueToPosition(double value) const {
         return static_cast<int>(m_a * value - m_b);
     }
@@ -127,6 +128,7 @@ class WOverview : public WWidget {
     QColor m_qColorBackground;
     QColor m_endOfTrackColor;
 
+    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
     WaveformMarkSet m_marks;
     std::vector<WaveformMarkRange> m_markRanges;
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -95,7 +95,6 @@ class WOverview : public WWidget {
     // Append the waveform overview pixmap according to available data in waveform
     virtual bool drawNextPixmapPart() = 0;
     void paintText(const QString &text, QPainter *painter);
-    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
     inline int valueToPosition(double value) const {
         return static_cast<int>(m_a * value - m_b);
     }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -128,7 +128,7 @@ class WOverview : public WWidget {
     QColor m_qColorBackground;
     QColor m_endOfTrackColor;
 
-    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
+    ColorsRepresentation m_predefinedColorsRepresentation;
     WaveformMarkSet m_marks;
     std::vector<WaveformMarkRange> m_markRanges;
 


### PR DESCRIPTION
This PR implements cue color overriding for skins. Skin designers can add color tags to override the predefined cue colors. So for example `<Yellow>#FFFF33</Yellow>` means that we want to use this lighter version of yellow instead of the predefined one. If a color is not overridden, the default one is used.
(See example commit.)

- Of course the colors can be set with `<Variable>`
- This PR only implements this for the main waveforms, i.e. `<Visual>` node.
- The `colors.h` file is quite a mess. Any suggestion on how to improve it is very welcome.