### PR TITLE
pre-commit: Add support for typescript hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,17 @@ repos:
     - manual
 - repo: local
   hooks:
+  - id: typescript
+    name: typescript
+    entry: tsc --noEmit --allowJs --checkJS
+    args: [--typeRoots, res/controllers/typings]
+    stages:
+    - commit
+    - manual
+    language: node
+    files: \.(js)$
+    additional_dependencies:
+    - typescript
   - id: clang-format
     name: clang-format
     entry: git clang-format


### PR DESCRIPTION
Can you test this?

I have never used typescript. How can I lint a controllerscript? This does not print any warnings:

    $ tsc --noEmit --allowJs res/controller/SomeController.js
