### PR TITLE
Tagfetcherratelimit

### DIFF
--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -45,8 +45,6 @@ class MusicBrainzRecordingsTask : public network::WebTask {
             int errorCode,
             const QString& errorMessage);
 
-    void continueWithNextRequest();
-
     const QUrlQuery m_urlQuery;
 
     QList<QUuid> m_queuedRecordingIds;

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -8,6 +8,7 @@
 
 #include "musicbrainz/musicbrainz.h"
 #include "network/webtask.h"
+#include "util/timer.h"
 
 namespace mixxx {
 
@@ -52,6 +53,8 @@ class MusicBrainzRecordingsTask : public network::WebTask {
     QSet<QUuid> m_finishedRecordingIds;
 
     QMap<QUuid, musicbrainz::TrackRelease> m_trackReleases;
+
+    Timer m_measurementTimer;
 
     int m_parentTimeoutMillis;
 };

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -128,12 +128,8 @@ void WebTask::onNetworkError(
 
     DEBUG_ASSERT(errorCode != QNetworkReply::NoError);
     switch (errorCode) {
-    case QNetworkReply::OperationCanceledError:
-        // Client-side abort or timeout
-        m_state = State::Aborted;
-        break;
-    case QNetworkReply::TimeoutError:
-        // Network or server-side timeout
+    case QNetworkReply::OperationCanceledError: // Client-side timeout
+    case QNetworkReply::TimeoutError:           // Network or server-side timeout
         m_state = State::TimedOut;
         break;
     default:
@@ -141,14 +137,10 @@ void WebTask::onNetworkError(
     }
     DEBUG_ASSERT(hasTerminated());
 
-    if (m_state == State::Aborted) {
-        emitAborted(responseWithContent.requestUrl());
-    } else {
-        emitNetworkError(
-                errorCode,
-                errorString,
-                responseWithContent);
-    }
+    emitNetworkError(
+            errorCode,
+            errorString,
+            responseWithContent);
 }
 
 void WebTask::emitNetworkError(

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -214,11 +214,11 @@ void WebTask::slotStart(int timeoutMillis, int delayMillis) {
             pNetworkAccessManager,
             timeoutMillis);
     if (!m_pendingNetworkReplyWeakPtr) {
-        kLogger.debug()
-                << this
-                << "Network request has not been started";
-        m_state = State::Aborted;
-        emitAborted(/*request URL is unknown*/);
+        m_state = State::Failed;
+        onNetworkError(
+                QNetworkReply::NetworkSessionFailedError,
+                tr("Request URL issue, network request has not been started"),
+                WebResponseWithContent{});
         return;
     }
 

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -286,7 +286,6 @@ void WebTask::slotAbort() {
     QUrl requestUrl;
     auto* const pPendingNetworkReply = m_pendingNetworkReplyWeakPtr.data();
     if (pPendingNetworkReply) {
-        DEBUG_ASSERT(m_state == State::Pending);
         if (pPendingNetworkReply->isRunning()) {
             kLogger.debug()
                     << this

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -148,7 +148,7 @@ class WebTask : public NetworkTask {
 
     enum class State {
         // Initial state
-        Idle,
+        Initial,
         // Timed start
         Starting,
         // Pending state


### PR DESCRIPTION
This is the second part of the PR taken from https://github.com/mixxxdj/mixxx/pull/10822

It calculates the time from the start of the request instead of the time in between. 
It also cleans up the state chart and fixes the stalled Window on case of client side timeout. 